### PR TITLE
Micro optimizations : BuildGraph

### DIFF
--- a/swift/Traktor_Transition_Finder/Traktor Transition Finder/Graph.swift
+++ b/swift/Traktor_Transition_Finder/Traktor Transition Finder/Graph.swift
@@ -22,7 +22,6 @@ struct Song {
 
 struct Edge {
     let Weight: Double
-    let From: Song
     let To: Song
 }
 struct XMLEntry {
@@ -199,7 +198,7 @@ class Graph {
                     let keyWeight = weightForKey(key: fromSong.Key, other: toSong.Key)
                     
                     let weight = bpmDifference + keyWeight
-                    return Edge (Weight: weight, From: fromSong, To: toSong)
+                    return Edge (Weight: weight, To: toSong)
                 }
                 
                 //let otherSongs = songs.filter({ (element) -> Bool in element != song })

--- a/swift/Traktor_Transition_Finder/Traktor Transition Finder/Graph.swift
+++ b/swift/Traktor_Transition_Finder/Traktor Transition Finder/Graph.swift
@@ -191,9 +191,8 @@ class Graph {
                         ]
                         
                         //See if other key matches any of the good key transitions.
-                        let filtered = lst.filter({(x: Int) -> Bool in other.0 == x})
                         //If there were any matches, then it's a nice key transition.
-                        return filtered.count == 0 ? BADKEYWEIGHT : 0.0
+                        return lst.contains(other.0) ? 0.0 : BADKEYWEIGHT
                     }
                     
                     let bpmDifference = abs(fromSong.BPM - toSong.BPM)


### PR DESCRIPTION
(could not get the app compiling/running on ubuntu so I don't know how much this will affect the build graph performance)

### Two Changes: 

- use contains instead of filter to avoid unneccesary creation of lists
- Removed `From` field, from Edge struct since edges always are placed on the "from" Node anyway. Decreasing the amount of memory being copied around.

The second change affects the data structure design a bit, so let me know if you want it or not.