### PR TITLE
Optimization by Struct->Class

### DIFF
--- a/swift/Traktor_Transition_Finder/Traktor Transition Finder/Graph.swift
+++ b/swift/Traktor_Transition_Finder/Traktor Transition Finder/Graph.swift
@@ -7,7 +7,7 @@ import Foundation
 import SWXMLHash
 
 enum Chord { case Major,  Minor, Invalid }
-struct Song {
+class Song {
     let BPM: Double
     let Title: String
     let Artist: String
@@ -20,12 +20,12 @@ struct Song {
     }
 }
 
-struct Edge {
+class Edge {
     let Weight: Double
     let From: Song
     let To: Song
 }
-struct XMLEntry {
+class XMLEntry {
     let BPM: String?
     let Title: String?
     let Artist: String?


### PR DESCRIPTION
As stated here: https://stackoverflow.com/questions/24217586/structure-vs-class-in-swift-language
Structs are always passed as copies, whereas Classes are copied by reference. Using structs can therefore heavily impact performance due to unneccesary memory allocation+copy and memory deallocations. 

This may however impact functionality so test well before merge :) 
